### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/automation-tests.yml
+++ b/.github/workflows/automation-tests.yml
@@ -1,5 +1,9 @@
 name: Automation Tests
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/beercanx/oauth-api/security/code-scanning/3](https://github.com/beercanx/oauth-api/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow:
- `contents: read` is required for actions like `checkout`.
- `actions: write` is required for uploading artifacts.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the `test` job to limit permissions to that specific job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
