### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ui-ci-using-npm.yml
+++ b/.github/workflows/ui-ci-using-npm.yml
@@ -11,6 +11,9 @@ on:
     paths:
       - "user-interface/**"
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/beercanx/oauth-api/security/code-scanning/4](https://github.com/beercanx/oauth-api/security/code-scanning/4)

To fix the issue, add a `permissions` block to the workflow. Since the workflow primarily involves checking out code, setting up Node.js, installing dependencies, building the project, and running tests, it only requires read access to the repository contents. Therefore, the `permissions` block should be added at the root level of the workflow to apply to all jobs, with `contents: read` as the minimal required permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
